### PR TITLE
Bytes-like support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ use axum_extra::TypedHeader;
 use axum_extra::headers::Range;
 
 use tokio::fs::File;
+use std::io::Cursor;
+use bytes::Bytes;
 
 use axum_range::Ranged;
 use axum_range::KnownSize;
@@ -20,6 +22,15 @@ use axum_range::KnownSize;
 async fn file(range: Option<TypedHeader<Range>>) -> Ranged<KnownSize<File>> {
     let file = File::open("archlinux-x86_64.iso").await.unwrap();
     let body = KnownSize::file(file).await.unwrap();
+    let range = range.map(|TypedHeader(range)| range);
+    Ranged::new(range, body)
+}
+
+async fn bytes(range: Option<TypedHeader<Range>>) -> Ranged<KnownSize<Cursor<Bytes>>> {
+    let buffer = tokio::fs::read("cat.jpg").await.unwrap();
+    // processing data here...
+    
+    let body = KnownSize::bytes(buffer);
     let range = range.map(|TypedHeader(range)| range);
     Ranged::new(range, body)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //! use axum_extra::headers::Range;
 //!
 //! use tokio::fs::File;
+//! use std::io::Cursor;
+//! use bytes::Bytes;
 //!
 //! use axum_range::Ranged;
 //! use axum_range::KnownSize;
@@ -26,6 +28,15 @@
 //! async fn file(range: Option<TypedHeader<Range>>) -> Ranged<KnownSize<File>> {
 //!     let file = File::open("The Sims 1 - The Complete Collection.rar").await.unwrap();
 //!     let body = KnownSize::file(file).await.unwrap();
+//!     let range = range.map(|TypedHeader(range)| range);
+//!     Ranged::new(range, body)
+//! }
+//!
+//! async fn bytes(range: Option<TypedHeader<Range>>) -> Ranged<KnownSize<Cursor<Bytes>>> {
+//!     let buffer = tokio::fs::read("cat.jpg").await.unwrap();
+//!     // processing data here...
+//!     
+//!     let body = KnownSize::bytes(buffer);
 //!     let range = range.map(|TypedHeader(range)| range);
 //!     Ranged::new(range, body)
 //! }


### PR DESCRIPTION
This is a PR for Issue #8.
Add support for `Bytes` and `Vec<u8>` and add documentation.
Add `KnownSize::bytes(bytes: Into<Bytes>) -> KnownSize<Cursor<Bytes>>` use `Cursor` to wrap.

I've already tested the correctness of bytes using the lib.rs tests, but to avoid excessive code duplication, I haven't included it.
replace `tests::body` to this.
```rust
async fn body() -> KnownSize<Cursor<Bytes>> {
    let data: Vec<u8> = tokio::fs::read("test/fixture.txt").await.unwrap();
    KnownSize::bytes(data).await.unwrap()
}
```
Is it possible to relax the condition that `File` and `Cursor<Bytes>` are not the same does without converting it to a `Respnose`?
